### PR TITLE
Refactor user id to a new type that can handle new accounts

### DIFF
--- a/src/api/playlist/change_playlist_visibility.rs
+++ b/src/api/playlist/change_playlist_visibility.rs
@@ -4,12 +4,13 @@ use reqwest::Method;
 
 use crate::{
     api::Endpoint, client::request::RequestOptions, model::playlist::Playlist, YandexMusicClient,
+    UserId,
 };
 
 /// Request for changing a playlist's visibility.
 pub struct ChangePlaylistVisibilityOptions {
     /// The ID of the user who owns the playlist.
-    pub user_id: i32,
+    pub user_id: UserId,
     /// The kind (ID) of the playlist.
     pub kind: i32,
     /// The new visibility value ("public" or "private").
@@ -18,7 +19,7 @@ pub struct ChangePlaylistVisibilityOptions {
 
 impl ChangePlaylistVisibilityOptions {
     /// Create a new request to change a playlist's visibility.
-    pub fn new(user_id: i32, kind: i32, value: impl Into<String>) -> Self {
+    pub fn new(user_id: UserId, kind: i32, value: impl Into<String>) -> Self {
         Self {
             user_id,
             kind,

--- a/src/api/playlist/create_playlist.rs
+++ b/src/api/playlist/create_playlist.rs
@@ -4,12 +4,13 @@ use reqwest::Method;
 
 use crate::{
     api::Endpoint, client::request::RequestOptions, model::playlist::Playlist, YandexMusicClient,
+    UserId
 };
 
 /// Request for creating a new playlist.
 pub struct CreatePlaylistOptions {
     /// The ID of the user who will own the playlist.
-    pub user_id: i32,
+    pub user_id: UserId,
     /// The title of the new playlist.
     pub title: String,
     /// The visibility of the playlist. Must be either "public" or "private".
@@ -18,7 +19,7 @@ pub struct CreatePlaylistOptions {
 
 impl CreatePlaylistOptions {
     /// Create a new request for creating a playlist.
-    pub fn new(user_id: i32, title: impl Into<String>, visibility: impl Into<String>) -> Self {
+    pub fn new(user_id: UserId, title: impl Into<String>, visibility: impl Into<String>) -> Self {
         Self {
             user_id,
             title: title.into(),

--- a/src/api/playlist/delete_playlist.rs
+++ b/src/api/playlist/delete_playlist.rs
@@ -2,19 +2,19 @@ use std::borrow::Cow;
 
 use reqwest::Method;
 
-use crate::{api::Endpoint, client::request::RequestOptions, YandexMusicClient};
+use crate::{api::Endpoint, client::request::RequestOptions, YandexMusicClient, UserId};
 
 /// Request for deleting a playlist.
 pub struct DeletePlaylistOptions {
     /// The ID of the user who owns the playlist.
-    pub user_id: i32,
+    pub user_id: UserId,
     /// The kind (ID) of the playlist to delete.
     pub kind: i32,
 }
 
 impl DeletePlaylistOptions {
     /// Create a new request for deleting a playlist.
-    pub fn new(user_id: i32, kind: i32) -> Self {
+    pub fn new(user_id: UserId, kind: i32) -> Self {
         Self { user_id, kind }
     }
 }

--- a/src/api/playlist/get_all_playlists.rs
+++ b/src/api/playlist/get_all_playlists.rs
@@ -4,14 +4,15 @@ use reqwest::Method;
 
 use crate::{
     api::Endpoint, client::request::RequestOptions, model::playlist::Playlist, YandexMusicClient,
+    UserId,
 };
 
 pub struct GetAllPlaylistsOptions {
-    pub user_id: i32,
+    pub user_id: UserId,
 }
 
 impl GetAllPlaylistsOptions {
-    pub fn new(user_id: i32) -> Self {
+    pub fn new(user_id: UserId) -> Self {
         Self { user_id }
     }
 }

--- a/src/api/playlist/get_playlist.rs
+++ b/src/api/playlist/get_playlist.rs
@@ -4,19 +4,20 @@ use reqwest::Method;
 
 use crate::{
     api::Endpoint, client::request::RequestOptions, model::playlist::Playlist, YandexMusicClient,
+    UserId,
 };
 
 /// Request for getting a specific playlist.
 pub struct GetPlaylistOptions {
     /// The ID of the user who owns the playlist.
-    pub user_id: i32,
+    pub user_id: UserId,
     /// The kind (ID) of the playlist.
     pub kind: i32,
 }
 
 impl GetPlaylistOptions {
     /// Create a new request for getting a specific playlist.
-    pub fn new(user_id: i32, kind: i32) -> Self {
+    pub fn new(user_id: UserId, kind: i32) -> Self {
         Self { user_id, kind }
     }
 }

--- a/src/api/playlist/get_playlists.rs
+++ b/src/api/playlist/get_playlists.rs
@@ -4,12 +4,13 @@ use reqwest::Method;
 
 use crate::{
     api::Endpoint, client::request::RequestOptions, model::playlist::Playlist, YandexMusicClient,
+    UserId
 };
 
 /// Request for getting user's playlists.
 pub struct GetPlaylistsOptions {
     /// The ID of the user whose playlists to retrieve.
-    pub user_id: i32,
+    pub user_id: UserId,
     /// Specific playlist kinds to include. If empty, all playlists are returned.
     pub kinds: Vec<i32>,
     /// Whether to include mixed content in the response.
@@ -22,7 +23,7 @@ pub struct GetPlaylistsOptions {
 
 impl GetPlaylistsOptions {
     /// Create a new request for getting user's playlists.
-    pub fn new(user_id: i32) -> Self {
+    pub fn new(user_id: UserId) -> Self {
         Self {
             user_id,
             kinds: Vec::new(),

--- a/src/api/playlist/get_recommendations.rs
+++ b/src/api/playlist/get_recommendations.rs
@@ -1,16 +1,16 @@
 use crate::client::request::RequestOptions;
-use crate::{api::Endpoint, model::track::Track, YandexMusicClient};
+use crate::{api::Endpoint, model::track::Track, YandexMusicClient, UserId};
 use reqwest::Method;
 use serde_json::Value;
 use std::borrow::Cow;
 
 pub struct GetRecommendationsOptions {
-    pub user_id: i32,
+    pub user_id: UserId,
     pub kind: i32,
 }
 
 impl GetRecommendationsOptions {
-    pub fn new(user_id: i32, kind: i32) -> Self {
+    pub fn new(user_id: UserId, kind: i32) -> Self {
         Self { user_id, kind }
     }
 }

--- a/src/api/playlist/modify_playlist.rs
+++ b/src/api/playlist/modify_playlist.rs
@@ -8,12 +8,13 @@ use crate::{
     client::request::RequestOptions,
     model::playlist::{modify::Diff, Playlist},
     YandexMusicClient,
+    UserId,
 };
 
 /// Request for modifying a playlist by adding or removing tracks.
 pub struct ModifyPlaylistOptions<'a> {
     /// The ID of the user who owns the playlist.
-    pub user_id: i32,
+    pub user_id: UserId,
     /// The kind (ID) of the playlist to modify.
     pub kind: i32,
     /// The diff object containing the changes to apply.
@@ -24,7 +25,7 @@ pub struct ModifyPlaylistOptions<'a> {
 
 impl<'a> ModifyPlaylistOptions<'a> {
     /// Create a new request to modify a playlist.
-    pub fn new(user_id: i32, kind: i32, diff: &'a Diff, revision: i32) -> Self {
+    pub fn new(user_id: UserId, kind: i32, diff: &'a Diff, revision: i32) -> Self {
         Self {
             user_id,
             kind,

--- a/src/api/playlist/rename_playlist.rs
+++ b/src/api/playlist/rename_playlist.rs
@@ -4,12 +4,13 @@ use reqwest::Method;
 
 use crate::{
     api::Endpoint, client::request::RequestOptions, model::playlist::Playlist, YandexMusicClient,
+    UserId
 };
 
 /// Request for renaming a playlist.
 pub struct RenamePlaylistOptions<'a> {
     /// The ID of the user who owns the playlist.
-    pub user_id: i32,
+    pub user_id: UserId,
     /// The kind (ID) of the playlist to rename.
     pub kind: i32,
     /// The new name for the playlist.
@@ -18,7 +19,7 @@ pub struct RenamePlaylistOptions<'a> {
 
 impl<'a> RenamePlaylistOptions<'a> {
     /// Create a new request to rename a playlist.
-    pub fn new(user_id: i32, kind: i32, value: &'a str) -> Self {
+    pub fn new(user_id: UserId, kind: i32, value: &'a str) -> Self {
         Self {
             user_id,
             kind,

--- a/src/api/track/add_liked_tracks.rs
+++ b/src/api/track/add_liked_tracks.rs
@@ -7,15 +7,16 @@ use crate::{
     client::request::RequestOptions,
     error::{ClientError, YandexMusicError},
     YandexMusicClient,
+    UserId
 };
 
 pub struct AddLikedTracksOptions {
-    pub user_id: i32,
+    pub user_id: UserId,
     pub track_ids: Vec<String>,
 }
 
 impl AddLikedTracksOptions {
-    pub fn new<S, I>(user_id: i32, track_ids: I) -> Self
+    pub fn new<S, I>(user_id: UserId, track_ids: I) -> Self
     where
         S: Into<String>,
         I: IntoIterator<Item = S>,

--- a/src/api/track/get_disliked_tracks.rs
+++ b/src/api/track/get_disliked_tracks.rs
@@ -6,17 +6,18 @@ use serde_json::Value;
 use crate::{
     api::Endpoint, client::request::RequestOptions,
     model::playlist::library::Library, YandexMusicClient,
+    UserId
 };
 
 /// Request for retrieving a user's disliked tracks.
 pub struct GetDislikedTracksOptions {
     /// The ID of the user whose disliked tracks to retrieve.
-    pub user_id: i32,
+    pub user_id: UserId,
 }
 
 impl GetDislikedTracksOptions {
     /// Create a new request to get a user's disliked tracks.
-    pub fn new(user_id: i32) -> Self {
+    pub fn new(user_id: UserId) -> Self {
         Self { user_id }
     }
 }

--- a/src/api/track/get_liked_tracks.rs
+++ b/src/api/track/get_liked_tracks.rs
@@ -6,17 +6,18 @@ use serde_json::Value;
 use crate::{
     api::Endpoint, client::request::RequestOptions,
     model::playlist::library::Library, YandexMusicClient,
+    UserId
 };
 
 /// Request for retrieving a user's liked tracks.
 pub struct GetLikedTracksOptions {
     /// The ID of the user whose liked tracks to retrieve.
-    pub user_id: i32,
+    pub user_id: UserId,
 }
 
 impl GetLikedTracksOptions {
     /// Create a new request to get a user's liked tracks.
-    pub fn new(user_id: i32) -> Self {
+    pub fn new(user_id: UserId) -> Self {
         Self { user_id }
     }
 }

--- a/src/api/track/play_audio.rs
+++ b/src/api/track/play_audio.rs
@@ -1,4 +1,4 @@
-use crate::{api::Endpoint, client::request::RequestOptions, YandexMusicClient};
+use crate::{api::Endpoint, client::request::RequestOptions, YandexMusicClient, UserId};
 use reqwest::Method;
 use std::borrow::Cow;
 
@@ -10,7 +10,7 @@ pub struct PlayAudioOptions {
     pub play_id: Option<String>,
     pub from: String,
     pub from_cache: Option<bool>,
-    pub uid: Option<i32>,
+    pub uid: Option<UserId>,
     pub track_length_seconds: Option<i32>,
     pub total_played_seconds: Option<i32>,
     pub end_position_seconds: Option<i32>,
@@ -51,7 +51,7 @@ impl PlayAudioOptions {
         self
     }
 
-    pub fn uid(mut self, uid: i32) -> Self {
+    pub fn uid(mut self, uid: UserId) -> Self {
         self.uid = Some(uid);
         self
     }

--- a/src/api/track/remove_liked_tracks.rs
+++ b/src/api/track/remove_liked_tracks.rs
@@ -8,15 +8,16 @@ use crate::{
     client::request::RequestOptions,
     error::{ClientError, YandexMusicError},
     YandexMusicClient,
+    UserId
 };
 
 pub struct RemoveLikedTracksOptions {
-    pub user_id: i32,
+    pub user_id: UserId,
     pub track_ids: Vec<String>,
 }
 
 impl RemoveLikedTracksOptions {
-    pub fn new<S, I>(user_id: i32, track_ids: I) -> Self
+    pub fn new<S, I>(user_id: UserId, track_ids: I) -> Self
     where
         S: Into<String>,
         I: IntoIterator<Item = S>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,8 @@ pub mod model;
 pub const API_PATH: &str = "https://api.music.yandex.net:443/";
 pub const DEFAULT_CLIENT_ID: &str = "YandexMusicAndroid/24023621";
 
+use crate::model::user::UserId;
+
 /// A client to interact with the Yandex Music API.
 pub struct YandexMusicClient {
     /// Internal reqwest client.

--- a/src/model/account/account_settings.rs
+++ b/src/model/account/account_settings.rs
@@ -1,9 +1,10 @@
 use serde::{Deserialize, Serialize};
+use crate::UserId;
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AccountSettings {
-    pub uid: i32,
+    pub uid: UserId,
     pub last_fm_scrobbling_enabled: bool,
     pub shuffle_enabled: bool,
     pub volume_percents: i32,

--- a/src/model/account/mod.rs
+++ b/src/model/account/mod.rs
@@ -3,12 +3,13 @@ pub mod promo_code;
 pub mod status;
 
 use serde::Deserialize;
+use crate::UserId;
 
 #[derive(Debug, PartialEq, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Account {
     pub now: String,
-    pub uid: Option<i32>,
+    pub uid: Option<UserId>,
     pub login: Option<String>,
     pub full_name: Option<String>,
     pub first_name: Option<String>,

--- a/src/model/playlist/id.rs
+++ b/src/model/playlist/id.rs
@@ -1,7 +1,8 @@
 use serde::Deserialize;
+use crate::UserId;
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize)]
 pub struct PlaylistId {
-    pub uid: i32,
+    pub uid: UserId,
     pub kind: i32,
 }

--- a/src/model/playlist/library.rs
+++ b/src/model/playlist/library.rs
@@ -1,11 +1,12 @@
 use serde::Deserialize;
+use crate::UserId;
 
 use crate::model::track::PartialTrack;
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Library {
-    pub uid: i32,
+    pub uid: UserId,
     pub revision: i32,
     pub tracks: Vec<PartialTrack>,
 }

--- a/src/model/playlist/mod.rs
+++ b/src/model/playlist/mod.rs
@@ -7,7 +7,7 @@ use serde::Deserialize;
 use crate::model::{
     info::tag::Tag,
     track::{cover::Cover, PartialTrack, Track, TrackWithInfo},
-    user::User,
+    user::{User, UserId},
 };
 
 #[derive(Debug, PartialEq, Clone, Deserialize)]
@@ -35,7 +35,7 @@ pub struct Playlist {
     pub tags: Vec<Tag>,
     pub title: String,
     pub track_count: i32,
-    pub uid: i32,
+    pub uid: UserId,
     pub visibility: String,
     #[serde(default)]
     pub likes_count: i32,

--- a/src/model/user/mod.rs
+++ b/src/model/user/mod.rs
@@ -1,9 +1,11 @@
 use serde::Deserialize;
 
+pub type UserId = u64;
+
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct User {
-    pub uid: i32,
+    pub uid: UserId,
     pub login: String,
     pub name: Option<String>,
     pub display_name: Option<String>,

--- a/src/model/user/mod.rs
+++ b/src/model/user/mod.rs
@@ -1,6 +1,8 @@
-use serde::Deserialize;
+use std::str::FromStr;
+use serde::{Serialize, Deserialize};
 
-pub type UserId = u64;
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
+pub struct UserId(u64);
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -14,4 +16,18 @@ pub struct User {
     pub verified: Option<bool>,
     #[serde(default)]
     pub regions: Vec<i32>,
+}
+
+impl std::fmt::Display for UserId {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(fmt, "{}", self.0)
+    }
+}
+
+impl FromStr for UserId {
+    type Err = std::num::ParseIntError;
+
+    fn from_str(parsee: &str) -> Result<Self, <Self as FromStr>::Err> {
+        Ok(Self ( parsee.parse()? ))
+    }
 }


### PR DESCRIPTION
I was creating this PR simply because my newly created account user id was `2230237061` which does not fit in `i32` 