### PR TITLE
feat: Add rotor runtime for wave continuation

### DIFF
--- a/src/api/rotor/mod.rs
+++ b/src/api/rotor/mod.rs
@@ -1,5 +1,6 @@
 pub mod create_session;
 pub mod get_all_stations;
+pub mod runtime;
 pub mod get_session_tracks;
 pub mod get_station;
 pub mod get_station_account_status;

--- a/src/api/rotor/runtime.rs
+++ b/src/api/rotor/runtime.rs
@@ -1,0 +1,165 @@
+use std::time::Duration;
+
+use crate::{
+    error::{ClientError, YandexMusicError},
+    model::{
+        rotor::{
+            feedback::StationFeedback,
+            session::Session,
+        },
+        track::Track,
+    },
+    YandexMusicClient,
+};
+
+use super::{
+    create_session::CreateSessionOptions,
+    get_station_tracks::GetStationTracksOptions,
+    send_station_feedback::GetStationFeedbackOptions,
+};
+
+const DEFAULT_HISTORY_LIMIT: usize = 20;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RotorSessionRuntime {
+    pub session: Session,
+    pub station_id: String,
+    pub from: String,
+    pub history: Vec<String>,
+    history_limit: usize,
+}
+
+impl RotorSessionRuntime {
+    pub fn from_session(session: Session) -> Result<Self, ClientError> {
+        let station_id = session
+            .wave
+            .as_ref()
+            .map(|wave| wave.station_id.clone())
+            .or_else(|| session.radio_session_id.clone())
+            .ok_or_else(missing_runtime_context)?;
+
+        let from = session
+            .wave
+            .as_ref()
+            .map(|wave| wave.id_for_from.clone())
+            .unwrap_or_else(|| "rotor".to_string());
+
+        Ok(Self {
+            session,
+            station_id,
+            from,
+            history: Vec::new(),
+            history_limit: DEFAULT_HISTORY_LIMIT,
+        })
+    }
+
+    pub fn batch_id(&self) -> &str {
+        &self.session.batch_id
+    }
+
+    pub fn with_history_limit(mut self, limit: usize) -> Self {
+        self.history_limit = limit.max(1);
+        self
+    }
+
+    pub fn record_track(&mut self, track: &Track) -> Option<String> {
+        let seed = track_seed(track)?;
+        self.history.insert(0, seed.clone());
+        self.history.truncate(self.history_limit);
+        Some(seed)
+    }
+
+    pub fn current_track_id(&self) -> Option<&str> {
+        self.history
+            .first()
+            .and_then(|seed| seed.split(':').next())
+    }
+
+    pub fn feedback(&self, item_type: impl Into<String>) -> StationFeedback {
+        StationFeedback::new(item_type).with_from(self.from.clone())
+    }
+
+    pub fn radio_started_feedback(&self) -> StationFeedback {
+        StationFeedback::radio_started(self.from.clone())
+    }
+
+    pub fn track_started_feedback(&self, track: &Track) -> StationFeedback {
+        StationFeedback::track_started(track.id.clone(), self.from.clone())
+    }
+
+    pub fn track_finished_feedback(
+        &self,
+        track: &Track,
+        total_played: Duration,
+    ) -> StationFeedback {
+        StationFeedback::track_finished(track.id.clone(), self.from.clone(), total_played)
+    }
+
+    pub fn skip_feedback(&self, track: &Track, total_played: Duration) -> StationFeedback {
+        StationFeedback::skip(track.id.clone(), self.from.clone(), total_played)
+    }
+}
+
+impl YandexMusicClient {
+    pub async fn start_rotor_session<I, S>(
+        &self,
+        seeds: I,
+    ) -> Result<RotorSessionRuntime, ClientError>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let session = self.create_session(CreateSessionOptions::new(seeds)).await?;
+        RotorSessionRuntime::from_session(session)
+    }
+
+    pub async fn continue_rotor_session(
+        &self,
+        runtime: &mut RotorSessionRuntime,
+        current_track: Option<&Track>,
+    ) -> Result<Vec<Track>, ClientError> {
+        if let Some(track) = current_track {
+            runtime.record_track(track);
+        }
+
+        let mut options = GetStationTracksOptions::new(runtime.station_id.clone()).settings2(true);
+        if let Some(queue) = runtime.current_track_id() {
+            options = options.queue(queue.to_string());
+        }
+
+        let response = self.get_station_tracks(&options).await?;
+        runtime.session.batch_id = response.batch_id.clone();
+
+        Ok(response.sequence.into_iter().map(|item| item.track).collect())
+    }
+
+    pub async fn send_rotor_feedback(
+        &self,
+        runtime: &RotorSessionRuntime,
+        feedback: StationFeedback,
+    ) -> Result<(), ClientError> {
+        let options = GetStationFeedbackOptions::new(runtime.station_id.clone(), feedback)
+            .batch_id(runtime.batch_id().to_string());
+        self.send_station_feedback(&options).await
+    }
+}
+
+fn track_seed(track: &Track) -> Option<String> {
+    let album_id = track
+        .albums
+        .first()
+        .and_then(|album| album.id.as_ref().map(|id| id.to_string()))?;
+
+    Some(format!("{}:{}", track.id, album_id))
+}
+
+fn missing_runtime_context() -> ClientError {
+    ClientError::YandexMusicError {
+        error: YandexMusicError {
+            name: "MissingRotorRuntimeContext".to_string(),
+            message: Some(
+                "Rotor session does not contain station_id or radio_session_id".to_string(),
+            ),
+        },
+    }
+}

--- a/src/api/rotor/send_station_feedback.rs
+++ b/src/api/rotor/send_station_feedback.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 
 use reqwest::Method;
+use serde_json::to_value;
 
 use crate::{
     api::Endpoint, client::request::RequestOptions,
@@ -74,7 +75,37 @@ impl YandexMusicClient {
         &self,
         options: &GetStationFeedbackOptions,
     ) -> Result<(), crate::ClientError> {
-        self.request::<(), _>(options).await?;
+        let url = if let Some(batch_id) = &options.batch_id {
+            format!(
+                "https://api.music.yandex.net/rotor/station/{}/feedback?batch-id={}",
+                options.station_id, batch_id
+            )
+        } else {
+            format!(
+                "https://api.music.yandex.net/rotor/station/{}/feedback",
+                options.station_id
+            )
+        };
+
+        let response = self
+            .inner
+            .post(url)
+            .json(&to_value(&options.feedback)?)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            return Err(crate::error::ClientError::YandexMusicError {
+                error: crate::error::YandexMusicError {
+                    name: "RequestFailed".to_string(),
+                    message: Some(format!(
+                        "Request failed with status code: {}",
+                        response.status()
+                    )),
+                },
+            });
+        }
+
         Ok(())
     }
 }

--- a/src/model/rotor/feedback.rs
+++ b/src/model/rotor/feedback.rs
@@ -1,19 +1,110 @@
 use std::time::Duration;
 
-use chrono::{DateTime, Utc};
-use serde::Serialize;
+use chrono::{DateTime, SecondsFormat, Utc};
+use serde::{Serialize, Serializer};
 
 #[derive(Debug, PartialEq, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct StationFeedback {
     #[serde(rename = "type")]
     pub item_type: String,
+    #[serde(serialize_with = "serialize_timestamp_millis")]
     pub timestamp: DateTime<Utc>,
-    pub from: String,
-    pub track_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub from: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub track_id: Option<String>,
     #[serde(
         rename = "totalPlayedSeconds",
-        serialize_with = "crate::model::utils::duration_to_secs"
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_optional_duration_to_secs"
     )]
-    pub total_played: Duration,
+    pub total_played: Option<Duration>,
+}
+
+fn serialize_timestamp_millis<S>(
+    value: &DateTime<Utc>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_str(&value.to_rfc3339_opts(SecondsFormat::Millis, true))
+}
+
+impl StationFeedback {
+    pub fn new(item_type: impl Into<String>) -> Self {
+        Self {
+            item_type: item_type.into(),
+            timestamp: Utc::now(),
+            from: None,
+            track_id: None,
+            total_played: None,
+        }
+    }
+
+    pub fn radio_started(from: impl Into<String>) -> Self {
+        Self::new("radioStarted").with_from(from)
+    }
+
+    pub fn track_started(track_id: impl Into<String>, from: impl Into<String>) -> Self {
+        Self::new("trackStarted")
+            .with_track_id(track_id)
+            .with_from(from)
+    }
+
+    pub fn track_finished(
+        track_id: impl Into<String>,
+        from: impl Into<String>,
+        total_played: Duration,
+    ) -> Self {
+        Self::new("trackFinished")
+            .with_track_id(track_id)
+            .with_from(from)
+            .with_total_played(total_played)
+    }
+
+    pub fn skip(
+        track_id: impl Into<String>,
+        from: impl Into<String>,
+        total_played: Duration,
+    ) -> Self {
+        Self::new("skip")
+            .with_track_id(track_id)
+            .with_from(from)
+            .with_total_played(total_played)
+    }
+
+    pub fn with_timestamp(mut self, timestamp: DateTime<Utc>) -> Self {
+        self.timestamp = timestamp;
+        self
+    }
+
+    pub fn with_from(mut self, from: impl Into<String>) -> Self {
+        self.from = Some(from.into());
+        self
+    }
+
+    pub fn with_track_id(mut self, track_id: impl Into<String>) -> Self {
+        self.track_id = Some(track_id.into());
+        self
+    }
+
+    pub fn with_total_played(mut self, total_played: Duration) -> Self {
+        self.total_played = Some(total_played);
+        self
+    }
+}
+
+fn serialize_optional_duration_to_secs<S>(
+    value: &Option<Duration>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    match value {
+        Some(duration) => serializer.serialize_f64(duration.as_secs_f64()),
+        None => serializer.serialize_none(),
+    }
 }


### PR DESCRIPTION

  The crate already exposes the low-level Rotor endpoints (`create_session`, `get_session_tracks`, `get_station_tracks`,
  `send_station_feedback`), but it does not provide a working high-level flow for live "My Wave" playback.

  In practice, a client needs to keep and update runtime state across requests:
  - current `batch_id`
  - `station_id`
  - `from`
  - played track history used for continuation

  Using only `create_session` + `get_session_tracks` was not sufficient for stable wave continuation in a real player. A
  working flow required station-based continuation plus feedback events.

  ## What changed

  This PR adds a high-level Rotor runtime API:

  - `api::rotor::runtime::RotorSessionRuntime`
  - `YandexMusicClient::start_rotor_session(...)`
  - `YandexMusicClient::continue_rotor_session(...)`
  - `YandexMusicClient::send_rotor_feedback(...)`

  It also makes `StationFeedback` flexible enough for real Rotor events:
  - `track_id` is now optional
  - `from` is now optional
  - `totalPlayedSeconds` is now optional

  This is required for events such as `radioStarted`, where track-specific fields are not always present.

  ## Design

  `RotorSessionRuntime` is intentionally placed in the `api::rotor` layer rather than `model`, because it is not a raw
  DTO from the API. It is a stateful runtime helper built on top of existing Rotor endpoints.

  The runtime keeps:
  - the current `Session`
  - `station_id`
  - `from`
  - local history used for continuation

  Continuation is performed through `get_station_tracks(..., settings2 = true)` and updates `batch_id` after each
  fetched batch.

  ## Feedback handling

  `send_station_feedback` was adjusted to send a direct POST request for the Rotor feedback endpoint.

  This endpoint turned out to be sensitive to the exact payload/serialization used in real clients. In particular:
  - timestamp is serialized as RFC3339 with milliseconds
  - the request body is sent directly to `/rotor/station/{station_id}/feedback?batch-id=...`

  This matches the request shape that worked in a real Yandex Music client integration.

  ## Example usage

  ```rust
  let mut runtime = client.start_rotor_session(["user:onyourwave"]).await?;

  client
      .send_rotor_feedback(&runtime, runtime.radio_started_feedback())
      .await?;

  let initial_tracks: Vec<_> = runtime
      .session
      .sequence
      .iter()
      .map(|item| item.track.clone())
      .collect();

  let current = &initial_tracks[0];

  client
      .send_rotor_feedback(&runtime, runtime.track_started_feedback(current))
      .await?;

  let next_tracks = client
      .continue_rotor_session(&mut runtime, Some(current))
      .await?;
