### PR TITLE
fix(model): make TrackFileInfo.size optional with serde(default)

### DIFF
--- a/src/model/info/file_info.rs
+++ b/src/model/info/file_info.rs
@@ -8,6 +8,7 @@ pub struct TrackFileInfo {
     pub gain: bool,
     pub quality: String,
     pub real_id: String,
+    #[serde(default)]
     pub size: u64,
     pub track_id: String,
     pub transport: String,

--- a/src/model/info/file_info.rs
+++ b/src/model/info/file_info.rs
@@ -8,8 +8,7 @@ pub struct TrackFileInfo {
     pub gain: bool,
     pub quality: String,
     pub real_id: String,
-    #[serde(default)]
-    pub size: u64,
+    pub size: Option<u64>,
     pub track_id: String,
     pub transport: String,
     pub url: String,


### PR DESCRIPTION
Yandex Music API may omit the `size` field in `get_file_info` / `get_file_info_batch` responses, causing deserialization to fail with "missing field `size`" for every track.

This one-line fix adds `#[serde(default)]` to `size` so it defaults to 0 when the field is absent. The value is informational and not used downstream — no breaking change.